### PR TITLE
Focused and Pending specs + ObjectMatcher.toBeInstanceOf()

### DIFF
--- a/oleaster-matcher/README.md
+++ b/oleaster-matcher/README.md
@@ -108,6 +108,9 @@ expect(person).toBeNotNull();
 // check if null
 person = null;
 expect(person).toBeNull();
+
+// check if instance of
+expect("Hello World!").toBeInstanceOf(String.class);
 ```
 
 For comparing Objects [ObjectMatcher](https://github.com/mscharhag/oleaster/blob/master/oleaster-matcher/src/main/java/com/mscharhag/oleaster/matcher/matchers/ObjectMatcher.java) will be used.

--- a/oleaster-matcher/src/main/java/com/mscharhag/oleaster/matcher/matchers/ObjectMatcher.java
+++ b/oleaster-matcher/src/main/java/com/mscharhag/oleaster/matcher/matchers/ObjectMatcher.java
@@ -16,8 +16,7 @@
 package com.mscharhag.oleaster.matcher.matchers;
 
 
-import static com.mscharhag.oleaster.matcher.util.Expectations.expectTrue;
-import static com.mscharhag.oleaster.matcher.util.Expectations.expectNotNull;
+import static com.mscharhag.oleaster.matcher.util.Expectations.*;
 
 /**
  * Matcher class to validate Objects of type {@code T}.
@@ -58,6 +57,15 @@ public class ObjectMatcher<T> {
 	 */
 	public void toBeNotNull() {
 		expectTrue(this.value != null, "Expected null to be not null");
+	}
+
+	/**
+	 * Checks if the stored value is an instance of the {@code expectedClass}
+	 *  <p>This method throws an {@code AssertionError} if the stored value is not of instance of {@code expectedClass}.
+	 * @param expectedClass
+	 */
+	public void toBeInstanceOf(Class<?> expectedClass) {
+		expectTrue(value.getClass().equals(expectedClass), "Expected '%s' to be instance of '%s'", this.value, expectedClass.getName());
 	}
 
 	protected T getValue() {

--- a/oleaster-matcher/src/main/java/com/mscharhag/oleaster/matcher/matchers/ObjectMatcher.java
+++ b/oleaster-matcher/src/main/java/com/mscharhag/oleaster/matcher/matchers/ObjectMatcher.java
@@ -65,7 +65,7 @@ public class ObjectMatcher<T> {
 	 * @param expectedClass
 	 */
 	public void toBeInstanceOf(Class<?> expectedClass) {
-		expectTrue(value.getClass().equals(expectedClass), "Expected '%s' to be instance of '%s'", this.value, expectedClass.getName());
+		expectTrue(expectedClass.isInstance(value), "Expected '%s' to be instance of '%s'", this.value, expectedClass.getName());
 	}
 
 	protected T getValue() {

--- a/oleaster-matcher/src/test/java/com/mscharhag/oleaster/matcher/matchers/ObjectMatcherTest.java
+++ b/oleaster-matcher/src/test/java/com/mscharhag/oleaster/matcher/matchers/ObjectMatcherTest.java
@@ -1,9 +1,10 @@
 package com.mscharhag.oleaster.matcher.matchers;
 
 import com.mscharhag.oleaster.runner.OleasterRunner;
+
 import org.junit.runner.RunWith;
 
-import static com.mscharhag.oleaster.matcher.TestUtil.expectAssertionError;
+import static com.mscharhag.oleaster.matcher.TestUtil.*;
 import static com.mscharhag.oleaster.runner.StaticRunnerSupport.*;
 
 @RunWith(OleasterRunner.class)
@@ -51,6 +52,16 @@ public class ObjectMatcherTest {{
 
 			it("is ok if the value is not null", () -> {
 				new ObjectMatcher<>("foo").toBeNotNull();
+			});
+		});
+
+		describe("when toBeInstanceOf() is called", () -> {
+			it("fails if the value is not of instance of input", () -> {
+				expectAssertionError(() -> new ObjectMatcher<>("foo").toBeInstanceOf(Integer.class), "Expected 'foo' to be instance of 'java.lang.Integer'");
+			});
+
+			it("is ok if the value is instance of the expected class", () -> {
+				new ObjectMatcher<>("foo").toBeInstanceOf(String.class);
 			});
 		});
 	});

--- a/oleaster-matcher/src/test/java/com/mscharhag/oleaster/matcher/matchers/ObjectMatcherTest.java
+++ b/oleaster-matcher/src/test/java/com/mscharhag/oleaster/matcher/matchers/ObjectMatcherTest.java
@@ -62,7 +62,36 @@ public class ObjectMatcherTest {{
 
 			it("is ok if the value is instance of the expected class", () -> {
 				new ObjectMatcher<>("foo").toBeInstanceOf(String.class);
+
 			});
+
+			it("is ok if the value is of the same class", () -> {
+				final Animal john = new Animal("John");
+				new ObjectMatcher<>(john).toBeInstanceOf(Animal.class);
+			});
+
+			it("is ok if the value is a child of the parent class", () -> {
+				final Dog marie = new Dog("Marie");
+				new ObjectMatcher<>(marie).toBeInstanceOf(Animal.class);
+			});
+
+			it("is not ok if the value is a parent of the child class", () -> {
+				final Animal bo = new Animal("Bo");
+				expectAssertionError(() -> new ObjectMatcher<>(bo).toBeInstanceOf(Dog.class), "Expected '" + bo + "' to be instance of '" + Dog.class.getName() + "'");
+			});
+
 		});
 	});
-}}
+}
+	public static class Animal {
+		public final String name;
+		public Animal(final String name) {
+			this.name = name;
+		}
+	}
+	public static class Dog extends Animal {
+		public Dog(final String name) {
+			super(name);
+		}
+	}
+}

--- a/oleaster-runner/README.md
+++ b/oleaster-runner/README.md
@@ -2,7 +2,7 @@ Oleaster Runner
 =====
 Oleaster Runner is a JUnit Runner that allows you to write JUnit tests like you would write Jasmine tests.
 
-````java
+```java
 import org.junit.runner.RunWith;
 import com.mscharhag.oleaster.runner.OleasterRunner;
 import static com.mscharhag.oleaster.runner.StaticRunnerSupport.*;
@@ -172,6 +172,70 @@ describe("before/after example", () -> {
 ```
 If `before()` or `after()` is used inside nested suites, `before()`/`after()` blocks of the outer suite
 will run first.
+
+## Focusing a test (run only a selection of tests)
+
+With `fdescribe()` and `fit()` it is possible to run a single test or a single suite:
+
+```java
+describe("Test suite", () -> {
+	it("test", () -> {
+		// I will not run
+		assertTrue(false);
+	});
+	
+	fit("focused test", () -> {
+		// I will run
+		assertTrue(true);
+	});
+	
+	fdescribe("focused suite", () -> {
+		it("test", () -> {
+			// I will be run
+			assertTrue(true);
+		});
+	});
+	
+	describe("normal suite", () -> {
+		it("test", () -> {
+			// I will not run
+			assertTrue(false);
+		});
+	});
+});
+```
+
+## Skipping a test
+
+With `xdescribe()` and `xit()` it is possible to disable a single test or single suite (mark as pending):
+
+```java
+describe("Test suite", () -> {
+	it("test", () -> {
+		// I will run
+		assertTrue(true);
+	});
+	
+	it("pending test");
+
+	xit("another pending test", () -> {
+		// I will not run
+		assertTrue(false);
+	});
+	
+	describe("normal suite", () -> {
+		it("test", () -> {
+			// I will run
+			assertTrue(true);
+		});	});
+	
+	xdescribe("pending suite", () -> {
+		it("test", () -> {
+			// I will not run
+			assertTrue(false);
+		});	});
+});
+```
 
 ## Assertions
 

--- a/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/OleasterRunner.java
+++ b/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/OleasterRunner.java
@@ -75,9 +75,14 @@ public class OleasterRunner extends ParentRunner<Spec> {
 			runBeforeCallbacks(spec);
 		}
 
-		runBeforeEachCallbacks(spec);
-		runLeaf(spec, describeChild(spec), notifier);
-		runAfterEachCallbacks(spec);
+		if (spec.getBlock().isPresent()) {
+			runBeforeEachCallbacks(spec);
+			runLeaf(spec, describeChild(spec), notifier);
+			runAfterEachCallbacks(spec);
+		} else {
+			notifier.fireTestIgnored(describeChild(spec));
+		}
+
 
 		if (suiteHasNoSpecs || isLastSpec){
 			runAfterCallbacks(spec);

--- a/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/PendingInvokable.java
+++ b/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/PendingInvokable.java
@@ -1,0 +1,4 @@
+package com.mscharhag.oleaster.runner;
+
+public interface PendingInvokable extends Invokable {
+}

--- a/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/PendingInvokable.java
+++ b/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/PendingInvokable.java
@@ -1,4 +1,3 @@
 package com.mscharhag.oleaster.runner;
 
-public interface PendingInvokable extends Invokable {
-}
+public interface PendingInvokable extends Invokable {}

--- a/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/StaticRunnerSupport.java
+++ b/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/StaticRunnerSupport.java
@@ -58,6 +58,28 @@ public class StaticRunnerSupport {
 	}
 
 	/**
+	 * Creates a focussed test suite.
+	 * <p>Test suites can contain:
+	 * <ul>
+	 *     	<li>specs (defined by using {@code it()}</li>
+	 *     	<li>other suites (defined by nesting {@code describe()} calls)</li>
+	 * 		<li>{@code beforeEach()} and {@code afterEach()} handlers.</li>
+	 * </ul>
+	 * <p>For example:
+	 * <pre>{@code
+	 * fdescribe("my test suite", () -> {
+	 *     ...
+	 * });
+	 * }</pre>
+	 * @param text A description of the test suite
+	 * @param block A code block that represents the test suite
+	 */
+	public static void fdescribe(String text, Invokable block) {
+		failIfNoSuiteBuilderAvailable("fdescribe");
+		suiteBuilder.fdescribe(text, block);
+	}
+
+	/**
 	 * Creates a pending test suite.
 	 * <p>Test suites can contain:
 	 * <ul>
@@ -96,6 +118,23 @@ public class StaticRunnerSupport {
 	public static void it(String text, Invokable block) {
 		failIfNoSuiteBuilderAvailable("it");
 		suiteBuilder.it(text, block);
+	}
+
+	/**
+	 * Create a new focussed spec.
+	 * <p>Focussed specs are used to temporarily only run these tests and disable the other specs.
+	 * <p>For example:
+	 * <pre>{@code
+	 * fit("returns a list containing one item", () -> {
+	 *   assertEquals(1, getList().size());
+	 * });
+	 * }</pre>
+	 * @param text A description of the expected behavior
+	 * @param block A code block that implements the validation
+	 */
+	public static void fit(String text, Invokable block) {
+		failIfNoSuiteBuilderAvailable("fit");
+		suiteBuilder.fit(text, block);
 	}
 
 	/**

--- a/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/StaticRunnerSupport.java
+++ b/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/StaticRunnerSupport.java
@@ -57,6 +57,29 @@ public class StaticRunnerSupport {
 		suiteBuilder.describe(text, block);
 	}
 
+	/**
+	 * Creates a pending test suite.
+	 * <p>Test suites can contain:
+	 * <ul>
+	 *     	<li>specs (defined by using {@code it()}</li>
+	 *     	<li>other suites (defined by nesting {@code describe()} calls)</li>
+	 * 		<li>{@code beforeEach()} and {@code afterEach()} handlers.</li>
+	 * </ul>
+	 * <p>For example:
+	 * <pre>{@code
+	 * xdescribe("my test suite", () -> {
+	 * 		// This will not be executed
+	 *     ...
+	 * });
+	 * }</pre>
+	 * @param text A description of the test suite
+	 * @param block A code block that represents the test suite
+	 */
+	public static void xdescribe(String text, PendingInvokable block) {
+		failIfNoSuiteBuilderAvailable("xdescribe");
+		suiteBuilder.xdescribe(text, block);
+	}
+
 
 	/**
 	 * Create a new spec.
@@ -73,6 +96,38 @@ public class StaticRunnerSupport {
 	public static void it(String text, Invokable block) {
 		failIfNoSuiteBuilderAvailable("it");
 		suiteBuilder.it(text, block);
+	}
+
+	/**
+	 * Create a new pending spec.
+	 * <p>Pending specs are used to temporarily disable specs.
+	 * <p>For example:
+	 * <pre>{@code
+	 * it("returns a list containing one item");
+	 * }</pre>
+	 * @param text A description of the expected behavior
+	 */
+	public static void it(String text) {
+		failIfNoSuiteBuilderAvailable("it");
+		suiteBuilder.xit(text);
+	}
+
+	/**
+	 * Create a new pending spec.
+	 * <p>Pending specs are used to temporarily disable specs.
+	 * <p>For example:
+	 * <pre>{@code
+	 * xit("returns a list containing one item", () -> {
+	 *   // This will not be executed.
+	 *   assertEquals(1, getList().size());
+	 * });
+	 * }</pre>
+	 * @param text A description of the expected behavior
+	 * @param block A code block that implements the validation
+	 */
+	public static void xit(String text, Invokable block) {
+		failIfNoSuiteBuilderAvailable("xit");
+		suiteBuilder.xit(text);
 	}
 
 

--- a/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/suite/Spec.java
+++ b/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/suite/Spec.java
@@ -15,16 +15,19 @@
 */
 package com.mscharhag.oleaster.runner.suite;
 
+import java.util.Optional;
+
 import com.mscharhag.oleaster.runner.Invokable;
+
 import org.junit.runners.model.Statement;
 
 public class Spec extends Statement {
 
 	private Suite suite;
 	private String description;
-	private Invokable block;
+	private Optional<Invokable> block;
 
-	public Spec(Suite suite, String description, Invokable block) {
+	public Spec(Suite suite, String description, Optional<Invokable> block) {
 		this.suite = suite;
 		this.description = description;
 		this.block = block;
@@ -48,6 +51,12 @@ public class Spec extends Statement {
 
 	@Override
 	public void evaluate() throws Throwable {
-		block.invoke();
+		if (block.isPresent()) {
+			block.get().invoke();
+		}
+	}
+
+	public Optional<Invokable> getBlock() {
+		return block;
 	}
 }

--- a/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/suite/SuiteBuilder.java
+++ b/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/suite/SuiteBuilder.java
@@ -28,7 +28,9 @@ import com.mscharhag.oleaster.runner.PendingInvokable;
 public class SuiteBuilder {
 
 	private Map<String, Invokable> suiteDefinitions;
+	private Map<String, Invokable> focusedSuiteDefinitions;
 	private Map<String, Optional<Invokable>> specDefinitions;
+	private Map<String, Optional<Invokable>> focusedSpecDefinitions;
 	private List<Invokable> beforeEachHandlers;
 	private List<Invokable> beforeHandlers;
 	private List<Invokable> afterEachHandlers;
@@ -40,7 +42,9 @@ public class SuiteBuilder {
 
 	private void prepare() {
 		this.suiteDefinitions = new LinkedHashMap<>();
+		this.focusedSuiteDefinitions = new LinkedHashMap<>();
 		this.specDefinitions = new LinkedHashMap<>();
+		this.focusedSpecDefinitions = new LinkedHashMap<>();
 		this.beforeHandlers = new ArrayList<>();
 		this.afterHandlers = new ArrayList<>();
 		this.beforeEachHandlers = new ArrayList<>();
@@ -60,13 +64,18 @@ public class SuiteBuilder {
 		this.suiteDefinitions.put(description, definition);
 	}
 
+	public void fdescribe(String description, Invokable definition) {
+		throwExceptionWhenSuiteDescriptionExists(description);
+		this.focusedSuiteDefinitions.put(description, definition);
+	}
+
 	public void xdescribe(String description, PendingInvokable definition) {
 		throwExceptionWhenSuiteDescriptionExists(description);
 		this.suiteDefinitions.put(description, definition);
 	}
 
 	private void throwExceptionWhenSuiteDescriptionExists(final String description) {
-		if (this.suiteDefinitions.containsKey(description)) {
+		if (this.suiteDefinitions.containsKey(description) || this.focusedSuiteDefinitions.containsKey(description)) {
 			throw new IllegalArgumentException(String.format("Suite with description '%s' does already exist", description));
 		}
 	}
@@ -76,13 +85,18 @@ public class SuiteBuilder {
 		this.specDefinitions.put(description, Optional.of(definition));
 	}
 
+	public void fit(String description, Invokable definition) {
+		throwExceptionWhenSpecDescriptionExists(description);
+		this.focusedSpecDefinitions.put(description, Optional.of(definition));
+	}
+
 	public void xit(String description) {
 		throwExceptionWhenSpecDescriptionExists(description);
 		this.specDefinitions.put(description, Optional.empty());
 	}
 
 	private void throwExceptionWhenSpecDescriptionExists(final String description) {
-		if (this.specDefinitions.containsKey(description)) {
+		if (this.specDefinitions.containsKey(description) || this.focusedSpecDefinitions.containsKey(description)) {
 			throw new IllegalArgumentException(String.format("Spec with description '%s' does already exist", description));
 		}
 	}
@@ -107,8 +121,16 @@ public class SuiteBuilder {
 		return suiteDefinitions;
 	}
 
+	public Map<String, Invokable> getFocusedSuiteDefinitions() {
+		return focusedSuiteDefinitions;
+	}
+
 	public Map<String, Optional<Invokable>> getSpecDefinitions() {
 		return specDefinitions;
+	}
+
+	public Map<String, Optional<Invokable>> getFocusedSpecDefinitions() {
+		return focusedSpecDefinitions;
 	}
 
 	public List<Invokable> getBeforeEachHandlers() {

--- a/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/suite/SuiteBuilder.java
+++ b/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/suite/SuiteBuilder.java
@@ -16,17 +16,19 @@
 package com.mscharhag.oleaster.runner.suite;
 
 
-import com.mscharhag.oleaster.runner.Invokable;
-
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
+import com.mscharhag.oleaster.runner.Invokable;
+import com.mscharhag.oleaster.runner.PendingInvokable;
 
 public class SuiteBuilder {
 
 	private Map<String, Invokable> suiteDefinitions;
-	private Map<String, Invokable> specDefinitions;
+	private Map<String, Optional<Invokable>> specDefinitions;
 	private List<Invokable> beforeEachHandlers;
 	private List<Invokable> beforeHandlers;
 	private List<Invokable> afterEachHandlers;
@@ -54,17 +56,35 @@ public class SuiteBuilder {
 	}
 
 	public void describe(String description, Invokable definition) {
-		if (this.suiteDefinitions.containsKey(description)) {
-			throw new IllegalArgumentException(String.format("Suite with description '%s' does already exist", description));
-		}
+		throwExceptionWhenSuiteDescriptionExists(description);
 		this.suiteDefinitions.put(description, definition);
 	}
 
+	public void xdescribe(String description, PendingInvokable definition) {
+		throwExceptionWhenSuiteDescriptionExists(description);
+		this.suiteDefinitions.put(description, definition);
+	}
+
+	private void throwExceptionWhenSuiteDescriptionExists(final String description) {
+		if (this.suiteDefinitions.containsKey(description)) {
+			throw new IllegalArgumentException(String.format("Suite with description '%s' does already exist", description));
+		}
+	}
+
 	public void it(String description, Invokable definition) {
+		throwExceptionWhenSpecDescriptionExists(description);
+		this.specDefinitions.put(description, Optional.of(definition));
+	}
+
+	public void xit(String description) {
+		throwExceptionWhenSpecDescriptionExists(description);
+		this.specDefinitions.put(description, Optional.empty());
+	}
+
+	private void throwExceptionWhenSpecDescriptionExists(final String description) {
 		if (this.specDefinitions.containsKey(description)) {
 			throw new IllegalArgumentException(String.format("Spec with description '%s' does already exist", description));
 		}
-		this.specDefinitions.put(description, definition);
 	}
 
 	public void beforeEach(Invokable block) {
@@ -87,7 +107,7 @@ public class SuiteBuilder {
 		return suiteDefinitions;
 	}
 
-	public Map<String, Invokable> getSpecDefinitions() {
+	public Map<String, Optional<Invokable>> getSpecDefinitions() {
 		return specDefinitions;
 	}
 

--- a/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/suite/SuiteDefinition.java
+++ b/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/suite/SuiteDefinition.java
@@ -16,18 +16,24 @@
 package com.mscharhag.oleaster.runner.suite;
 
 import com.mscharhag.oleaster.runner.Invokable;
+import com.mscharhag.oleaster.runner.PendingInvokable;
 
 public class SuiteDefinition {
 
 	private Suite parent;
 	private String description;
 	private Invokable block;
+	private boolean parentIsPending;
 
 
 	public SuiteDefinition(Suite parent, String description, Invokable block) {
+		this(parent, description, block, false);
+	}
+	public SuiteDefinition(Suite parent, String description, Invokable block, boolean parentIsPending) {
 		this.parent = parent;
 		this.description = description;
 		this.block = block;
+		this.parentIsPending = parentIsPending;
 	}
 
 	public Suite getParent() {
@@ -40,5 +46,9 @@ public class SuiteDefinition {
 
 	public Invokable getBlock() {
 		return block;
+	}
+
+	public boolean isPending() {
+		return block instanceof PendingInvokable || parentIsPending;
 	}
 }

--- a/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/suite/SuiteDefinitionEvaluator.java
+++ b/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/suite/SuiteDefinitionEvaluator.java
@@ -15,7 +15,10 @@
 */
 package com.mscharhag.oleaster.runner.suite;
 
+import java.util.Map;
 import java.util.Optional;
+
+import com.mscharhag.oleaster.runner.Invokable;
 
 public class SuiteDefinitionEvaluator {
 
@@ -47,13 +50,24 @@ public class SuiteDefinitionEvaluator {
 		suite.addAfterEachHandlers(suiteBuilder.getAfterEachHandlers());
 		suite.addAfterHandlers(suiteBuilder.getAfterHandlers());
 
-		suiteBuilder.getSpecDefinitions().forEach((description, block) ->
+		Map<String, Optional<Invokable>> specDefinitions = suiteBuilder.getFocusedSpecDefinitions().size() > 0
+				? suiteBuilder.getFocusedSpecDefinitions()
+				: suiteBuilder.getSpecDefinitions();
+
+		specDefinitions.forEach((description, block) ->
 				suite.addSpec(new Spec(suite, description, suiteDefinition.isPending() ? Optional.empty() : block)));
 
-		suiteBuilder.getSuiteDefinitions().forEach((description, block) -> {
-			SuiteDefinition childSuiteDefinition = new SuiteDefinition(suite, description, block, suiteDefinition.isPending());
-			suite.addChildSuite(this.evaluate(childSuiteDefinition, suiteBuilder));
-		});
+		if (suiteBuilder.getFocusedSuiteDefinitions().size() > 0) {
+			suiteBuilder.getFocusedSuiteDefinitions().forEach((description, block) -> {
+				SuiteDefinition childSuiteDefinition = new SuiteDefinition(suite, description, block, suiteDefinition.isPending());
+				suite.addChildSuite(this.evaluate(childSuiteDefinition, suiteBuilder));
+			});
+		} else {
+			suiteBuilder.getSuiteDefinitions().forEach((description, block) -> {
+				SuiteDefinition childSuiteDefinition = new SuiteDefinition(suite, description, block, suiteDefinition.isPending());
+				suite.addChildSuite(this.evaluate(childSuiteDefinition, suiteBuilder));
+			});
+		}
 
 		return suite;
 	}

--- a/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/suite/SuiteDefinitionEvaluator.java
+++ b/oleaster-runner/src/main/java/com/mscharhag/oleaster/runner/suite/SuiteDefinitionEvaluator.java
@@ -15,6 +15,8 @@
 */
 package com.mscharhag.oleaster.runner.suite;
 
+import java.util.Optional;
+
 public class SuiteDefinitionEvaluator {
 
 
@@ -45,12 +47,11 @@ public class SuiteDefinitionEvaluator {
 		suite.addAfterEachHandlers(suiteBuilder.getAfterEachHandlers());
 		suite.addAfterHandlers(suiteBuilder.getAfterHandlers());
 
-		suiteBuilder.getSpecDefinitions().forEach((description, block) -> {
-			suite.addSpec(new Spec(suite, description, block));
-		});
+		suiteBuilder.getSpecDefinitions().forEach((description, block) ->
+				suite.addSpec(new Spec(suite, description, suiteDefinition.isPending() ? Optional.empty() : block)));
 
 		suiteBuilder.getSuiteDefinitions().forEach((description, block) -> {
-			SuiteDefinition childSuiteDefinition = new SuiteDefinition(suite, description, block);
+			SuiteDefinition childSuiteDefinition = new SuiteDefinition(suite, description, block, suiteDefinition.isPending());
 			suite.addChildSuite(this.evaluate(childSuiteDefinition, suiteBuilder));
 		});
 

--- a/oleaster-runner/src/test/java/com/mscharhag/oleaster/runner/FocusedSpecTest.java
+++ b/oleaster-runner/src/test/java/com/mscharhag/oleaster/runner/FocusedSpecTest.java
@@ -1,0 +1,39 @@
+package com.mscharhag.oleaster.runner;
+
+import org.junit.runner.RunWith;
+
+import static com.mscharhag.oleaster.runner.StaticRunnerSupport.*;
+import static org.junit.Assert.*;
+
+@RunWith(OleasterRunner.class)
+public class FocusedSpecTest {{
+  describe("The focused spec", () -> {
+
+    fit("is focused and will run", () -> {
+      assertTrue(true);
+    });
+
+    it("is not focused and will not run" , () -> {
+      fail("fail");
+    });
+
+    fdescribe("focused describe", () -> {
+      it("will run", () -> {
+        assertTrue(true);
+      });
+      it("will also run", () -> {
+        assertTrue(true);
+      });
+    });
+
+    fdescribe("another focused describe", () -> {
+      fit("is focused and will run", () -> {
+        assertTrue(true);
+      });
+
+      it("is not focused and will not run", () -> {
+        fail("fail");
+      });
+    });
+  });
+}}

--- a/oleaster-runner/src/test/java/com/mscharhag/oleaster/runner/HandlerTest.java
+++ b/oleaster-runner/src/test/java/com/mscharhag/oleaster/runner/HandlerTest.java
@@ -1,15 +1,17 @@
 package com.mscharhag.oleaster.runner;
 
-import com.mscharhag.oleaster.runner.suite.Spec;
-import com.mscharhag.oleaster.runner.suite.Suite;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.notification.RunNotifier;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
+
+import com.mscharhag.oleaster.runner.suite.Spec;
+import com.mscharhag.oleaster.runner.suite.Suite;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.notification.RunNotifier;
 
 import static org.junit.Assert.*;
 
@@ -31,9 +33,9 @@ public class HandlerTest {
         calls = new ArrayList<>();
         runner = new OleasterRunner(TestClass.class);
         suite = new Suite(null, "suite");
-        first = new Spec(suite, "spec", block.apply("first-spec"));
-        second = new Spec(suite, "spec", block.apply("second-spec"));
-        spec = new Spec(suite, "spec", block.apply("spec"));
+        first = new Spec(suite, "spec", Optional.of(block.apply("first-spec")));
+        second = new Spec(suite, "spec", Optional.of(block.apply("second-spec")));
+        spec = new Spec(suite, "spec", Optional.of(block.apply("spec")));
     }
 
 
@@ -64,7 +66,7 @@ public class HandlerTest {
         suite.addBeforeHandler(block.apply("outerBefore"));
         Suite child = new Suite(suite, "child");
         child.addBeforeHandler(block.apply("innerBefore"));
-        runner.runChild(new Spec(child, "spec", block.apply("spec")), new RunNotifier());
+        runner.runChild(new Spec(child, "spec", Optional.of(block.apply("spec"))), new RunNotifier());
         assertEquals(Arrays.asList("outerBefore", "innerBefore", "spec"), calls);
     }
 
@@ -82,7 +84,7 @@ public class HandlerTest {
     public void itExecutesBeforeEachHandlersInSpecifiedOrder() {
         suite.addBeforeEachHandler(block.apply("first"));
         suite.addBeforeEachHandler(block.apply("second"));
-        runner.runChild(new Spec(suite, "spec", () -> {}), new RunNotifier());
+        runner.runChild(new Spec(suite, "spec", Optional.of(() -> {})), new RunNotifier());
         assertEquals(Arrays.asList("first", "second"), calls);
     }
 
@@ -91,7 +93,7 @@ public class HandlerTest {
     public void itExecutesAfterEachHandlersInSpecifiedOrder() {
         suite.addAfterEachHandler(block.apply("first"));
         suite.addAfterEachHandler(block.apply("second"));
-        runner.runChild(new Spec(suite, "spec", () -> {}), new RunNotifier());
+        runner.runChild(new Spec(suite, "spec", Optional.of(() -> {})), new RunNotifier());
         assertEquals(Arrays.asList("first", "second"), calls);
     }
 
@@ -99,7 +101,7 @@ public class HandlerTest {
     @Test
     public void itExecutesBeforeEachHandlersBeforeTheSpecIsExecuted() {
         suite.addBeforeEachHandler(block.apply("beforeEach"));
-        runner.runChild(new Spec(suite, "spec", block.apply("spec")), new RunNotifier());
+        runner.runChild(new Spec(suite, "spec", Optional.of(block.apply("spec"))), new RunNotifier());
         assertEquals(Arrays.asList("beforeEach", "spec"), calls);
     }
 
@@ -107,7 +109,7 @@ public class HandlerTest {
     @Test
     public void itExecutesAfterEachHandlersAfterTheSpecIsExecuted() {
         suite.addAfterEachHandler(block.apply("afterEach"));
-        runner.runChild(new Spec(suite, "spec", block.apply("spec")), new RunNotifier());
+        runner.runChild(new Spec(suite, "spec", Optional.of(block.apply("spec"))), new RunNotifier());
         assertEquals(Arrays.asList("spec", "afterEach"), calls);
     }
 
@@ -117,7 +119,7 @@ public class HandlerTest {
         suite.addBeforeEachHandler(block.apply("outerBeforeEach"));
         Suite child = new Suite(suite, "child");
         child.addBeforeEachHandler(block.apply("innerBeforeEach"));
-        runner.runChild(new Spec(child, "spec", () -> { }), new RunNotifier());
+        runner.runChild(new Spec(child, "spec", Optional.of(() -> {})), new RunNotifier());
         assertEquals(Arrays.asList("outerBeforeEach", "innerBeforeEach"), calls);
     }
 
@@ -127,8 +129,7 @@ public class HandlerTest {
         suite.addAfterEachHandler(block.apply("outerBeforeEach"));
         Suite child = new Suite(suite, "child");
         child.addAfterEachHandler(block.apply("innerBeforeEach"));
-        runner.runChild(new Spec(child, "spec", () -> {
-        }), new RunNotifier());
+        runner.runChild(new Spec(child, "spec", Optional.of(() -> {})), new RunNotifier());
         assertEquals(Arrays.asList("innerBeforeEach", "outerBeforeEach"), calls);
     }
 

--- a/oleaster-runner/src/test/java/com/mscharhag/oleaster/runner/PendingSpecTest.java
+++ b/oleaster-runner/src/test/java/com/mscharhag/oleaster/runner/PendingSpecTest.java
@@ -1,0 +1,56 @@
+package com.mscharhag.oleaster.runner;
+
+
+import org.junit.runner.RunWith;
+
+import static com.mscharhag.oleaster.runner.StaticRunnerSupport.*;
+import static junit.framework.TestCase.*;
+
+@RunWith(OleasterRunner.class)
+public class PendingSpecTest {{
+  describe("PendingSpecs", () -> {
+    describe("with a nested describe", () -> {
+      it("should be executed", () -> {
+        assertTrue(true);
+      });
+
+      xit("should not be executed", () -> {
+        fail("Pending it (xit) should not be executed!");
+      });
+
+      describe("a nested describe should be executed", () -> {
+        it("should be fine", () -> {
+          assertTrue(true);
+        });
+      });
+
+      xdescribe("a pending describe should not be executed", () -> {
+        it("should not be executed", () -> {
+          fail("'it' in 'xdescribe' should not be executed!");
+        });
+
+        describe("a describe with a xdescribe parent", () -> {
+          it("should not be executed", () -> {
+            fail("'it' in 'describe' with 'xdescribe' parent should not be executed!");
+          });
+
+          describe("a describe with a xdescribe grandparent", () -> {
+            it("should not be executed", () -> {
+              fail("'it' in 'describe' with 'xdescribe' grandparent should not be executed!");
+            });
+          });
+        });
+      });
+    });
+
+    it("should be executed", () -> {
+      assertTrue(true);
+    });
+
+    xit("should not be executed", () -> {
+      fail("Pending it (xit) should not be executed!");
+    });
+
+    it("another pending style of test");
+  });
+}}

--- a/oleaster-runner/src/test/java/com/mscharhag/oleaster/runner/SpecTest.java
+++ b/oleaster-runner/src/test/java/com/mscharhag/oleaster/runner/SpecTest.java
@@ -1,20 +1,21 @@
 package com.mscharhag.oleaster.runner;
 
+import java.util.Optional;
+
 import com.mscharhag.oleaster.runner.suite.Spec;
 import com.mscharhag.oleaster.runner.suite.Suite;
+
 import org.junit.runner.RunWith;
 
-import static com.mscharhag.oleaster.runner.StaticRunnerSupport.beforeEach;
-import static com.mscharhag.oleaster.runner.StaticRunnerSupport.describe;
-import static com.mscharhag.oleaster.runner.StaticRunnerSupport.it;
-import static org.junit.Assert.assertEquals;
+import static com.mscharhag.oleaster.runner.StaticRunnerSupport.*;
+import static org.junit.Assert.*;
 
 @RunWith(OleasterRunner.class)
 public class SpecTest {
 
 	private Suite suite;
 	private Spec spec;
-	private Invokable emptyInvokable = () -> {};
+	private Optional<Invokable> emptyInvokable = Optional.of(() -> {});
 
 {
 	describe("Spec", () -> {

--- a/oleaster-runner/src/test/java/com/mscharhag/oleaster/runner/SuiteBuilderTest.java
+++ b/oleaster-runner/src/test/java/com/mscharhag/oleaster/runner/SuiteBuilderTest.java
@@ -1,16 +1,15 @@
 package com.mscharhag.oleaster.runner;
 
-import com.mscharhag.oleaster.runner.suite.SuiteBuilder;
+import java.util.Arrays;
+import java.util.Optional;
 
-import static com.mscharhag.oleaster.runner.AssertUtil.assertEmptySuiteBuilderCollections;
-import static com.mscharhag.oleaster.runner.AssertUtil.expect;
-import static org.junit.Assert.*;
+import com.mscharhag.oleaster.runner.suite.SuiteBuilder;
 
 import org.junit.runner.RunWith;
 
-import java.util.Arrays;
-
+import static com.mscharhag.oleaster.runner.AssertUtil.*;
 import static com.mscharhag.oleaster.runner.StaticRunnerSupport.*;
+import static org.junit.Assert.*;
 
 @RunWith(OleasterRunner.class)
 public class SuiteBuilderTest {
@@ -67,7 +66,7 @@ public class SuiteBuilderTest {
 			});
 
 			it("returns the new spec", () -> {
-				assertEquals(invokable, suiteBuilder.getSpecDefinitions().get("new spec"));
+				assertEquals(Optional.of(invokable), suiteBuilder.getSpecDefinitions().get("new spec"));
 			});
 
 			it("is not possible to add another spec with the same name", () -> {


### PR DESCRIPTION
This PR covers issues:
- https://github.com/mscharhag/oleaster/issues/30 `toBeInstanceOf()` to `ObjectMatcher`.
- https://github.com/mscharhag/oleaster/issues/29 Running a single test or selection of tests.

It adds `toBeInstanceOf()` to object matcher:

```java
expect("Hello Oleaster").toBeInstanceOf(String.class);
```

It adds the [Jasmine style 'Focused specs'](https://jasmine.github.io/2.5/focused_specs.html), adding the ability to run a test or a set of tests on their own:

```java
describe("Suite", () -> {
    it("will not run", () -> {
        assertTrue(false);
    });

    fit("will run", () -> {
        assertTrue(true);
    });
});
```

It adds the [Jasmine style 'Pending specs'](https://jasmine.github.io/2.5/introduction#section-Pending_Specs), adding the ability to skip a test or set of tests:

```java
describe("Suite", () -> {
    xit("will not run", () -> {
        assertTrue(false);
    });

    it("will run", () -> {
        assertTrue(true);
    });
});
```